### PR TITLE
changed itemname to not strip leading '-' from YT video_id

### DIFF
--- a/tubeup/TubeUp.py
+++ b/tubeup/TubeUp.py
@@ -277,7 +277,7 @@ class TubeUp(object):
                                vid_meta['display_id']))
 
         # Replace illegal characters within identifer
-        itemname = re.sub('\W+', '-', itemname)
+        itemname = re.sub('[^a-zA-Z0-9-]+', '-', itemname)
 
         metadata = self.create_archive_org_metadata_from_youtubedl_meta(
             vid_meta)


### PR DESCRIPTION
per https://github.com/bibanon/tubeup/issues/88
changed itemname = re.sub('\W+', '-', itemname)
to 
itemname = re.sub('[^a-zA-Z0-9-]+', '-', itemname)
line 280